### PR TITLE
Provide basic IAP authentication functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 [![Build Status](https://travis-ci.com/saifulwebid/iapgo.svg?branch=master)](https://travis-ci.com/saifulwebid/iapgo)
 [![codecov](https://codecov.io/gh/saifulwebid/iapgo/branch/master/graph/badge.svg)](https://codecov.io/gh/saifulwebid/iapgo)
+
+iapgo is a Go library to help authenticating access to endpoints behind Google's [Cloud Identity-Aware Proxy](https://cloud.google.com/iap/).
+
+This library is heavily using [`golang.org/x/oauth2/google`](https://godoc.org/golang.org/x/oauth2/google) to handle credentials parsing and [authentication](https://cloud.google.com/iap/docs/authentication-howto).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/saifulwebid/iapgo
 
 go 1.12
+
+require golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
+cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/iap.go
+++ b/iap.go
@@ -2,6 +2,7 @@ package iapgo
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"golang.org/x/oauth2"
@@ -10,38 +11,44 @@ import (
 
 type credentialsFinderFn func(ctx context.Context, scopes ...string) (*google.Credentials, error)
 
-var (
-	credentialsFinder credentialsFinderFn = google.FindDefaultCredentials
-)
+var credentialsFinder credentialsFinderFn = google.FindDefaultCredentials
+
+var errUninitialized = errors.New("iapgo: unitialized Transport")
 
 type Transport struct {
-	clientID string
-
 	oauthTransport *oauth2.Transport
+}
+
+func newTransport(clientID string) (*Transport, error) {
+	transport := &Transport{}
+
+	creds, err := credentialsFinder(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	conf, err := google.JWTConfigFromJSON(creds.JSON)
+	if err != nil {
+		return nil, err
+	}
+
+	conf.PrivateClaims = map[string]interface{}{
+		"target_audience": clientID,
+	}
+
+	conf.UseIDToken = true
+
+	transport.oauthTransport = &oauth2.Transport{
+		Source: conf.TokenSource(context.Background()),
+		Base:   http.DefaultTransport,
+	}
+
+	return transport, nil
 }
 
 func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if t.oauthTransport == nil {
-		creds, err := credentialsFinder(context.Background())
-		if err != nil {
-			return nil, err
-		}
-
-		conf, err := google.JWTConfigFromJSON(creds.JSON)
-		if err != nil {
-			return nil, err
-		}
-
-		conf.PrivateClaims = map[string]interface{}{
-			"target_audience": t.clientID,
-		}
-
-		conf.UseIDToken = true
-
-		t.oauthTransport = &oauth2.Transport{
-			Source: conf.TokenSource(context.Background()),
-			Base:   http.DefaultTransport,
-		}
+		return nil, errUninitialized
 	}
 
 	return t.oauthTransport.RoundTrip(r)

--- a/iap.go
+++ b/iap.go
@@ -1,11 +1,48 @@
 package iapgo
 
 import (
+	"context"
 	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
-type Transport struct{}
+type credentialsFinderFn func(ctx context.Context, scopes ...string) (*google.Credentials, error)
+
+var (
+	credentialsFinder credentialsFinderFn = google.FindDefaultCredentials
+)
+
+type Transport struct {
+	clientID string
+
+	oauthTransport *oauth2.Transport
+}
 
 func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
-	return http.DefaultTransport.RoundTrip(r)
+	if t.oauthTransport == nil {
+		creds, err := credentialsFinder(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		conf, err := google.JWTConfigFromJSON(creds.JSON)
+		if err != nil {
+			return nil, err
+		}
+
+		conf.PrivateClaims = map[string]interface{}{
+			"target_audience": t.clientID,
+		}
+
+		conf.UseIDToken = true
+
+		t.oauthTransport = &oauth2.Transport{
+			Source: conf.TokenSource(context.Background()),
+			Base:   http.DefaultTransport,
+		}
+	}
+
+	return t.oauthTransport.RoundTrip(r)
 }

--- a/iap_test.go
+++ b/iap_test.go
@@ -1,30 +1,243 @@
-package iapgo_test
+package iapgo
 
 import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
-	"github.com/saifulwebid/iapgo"
+	"golang.org/x/oauth2/google"
+	"golang.org/x/oauth2/jws"
 )
 
-var _ http.RoundTripper = new(iapgo.Transport)
+// Ensures Transport implements http.RoundTripper.
+var _ http.RoundTripper = new(Transport)
 
 func TestTransport_RoundTrip(t *testing.T) {
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI != "/" {
-			t.Fatal("request URI doesn't match")
-		}
+	clientID := "ABCD"
+
+	authSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAuthorizationRequest(t, r, clientID)
+		w.Write(mockTokenResponse(t))
 	}))
 
-	client := http.Client{
-		Transport: new(iapgo.Transport),
+	origCredentialsFinder := credentialsFinder
+	credentialsFinder = mockServiceAccountKey(t, authSvr.URL)
+	defer func() {
+		credentialsFinder = origCredentialsFinder
+	}()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAuthorizationHeader(t, r.Header.Get("Authorization"))
+	}))
+
+	client := &http.Client{
+		Transport: &Transport{
+			clientID: clientID,
+		},
 	}
 
-	req, err := http.NewRequest("GET", svr.URL, nil)
+	_, err := client.Get(svr.URL)
 	if err != nil {
-		t.Fatal("error creating a request")
+		t.Fatal("client.Get:", err)
+	}
+}
+
+func TestTransport_RoundTrip_CredentialsError(t *testing.T) {
+	origCredentialsFinder := credentialsFinder
+	credentialsFinder = brokenCredentialsFn
+	defer func() {
+		credentialsFinder = origCredentialsFinder
+	}()
+
+	client := &http.Client{
+		Transport: new(Transport),
 	}
 
-	client.Do(req)
+	_, err := client.Get("http://localhost")
+	switch {
+	case err == nil:
+		t.Fatal("no error, want some")
+	case !strings.HasSuffix(err.Error(), "brokenCredentialsFn"):
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTransport_RoundTrip_JWTError(t *testing.T) {
+	origCredentialsFinder := credentialsFinder
+	credentialsFinder = mockUserCredentials(t, "http://localhost")
+	defer func() {
+		credentialsFinder = origCredentialsFinder
+	}()
+
+	client := &http.Client{
+		Transport: new(Transport),
+	}
+
+	_, err := client.Get("http://localhost")
+	switch {
+	case err == nil:
+		t.Fatal("no error, want some")
+	case !strings.HasSuffix(err.Error(), `'type' field is "authorized_user" (expected "service_account")`):
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func mockServiceAccountKey(t *testing.T, authURL string) credentialsFinderFn {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+
+	enc := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	jwtKey := struct {
+		Type       string `json:"type"`
+		TokenURI   string `json:"token_uri"`
+		PrivateKey string `json:"private_key"`
+	}{
+		Type:       "service_account",
+		TokenURI:   authURL,
+		PrivateKey: string(enc),
+	}
+
+	jsonKey, err := json.Marshal(jwtKey)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	return func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+		return google.CredentialsFromJSON(context.Background(), jsonKey, scopes...)
+	}
+}
+
+func mockUserCredentials(t *testing.T, authURL string) credentialsFinderFn {
+	t.Helper()
+
+	jwtKey := struct {
+		Type string `json:"type"`
+	}{
+		Type: "authorized_user",
+	}
+
+	jsonKey, err := json.Marshal(jwtKey)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	return func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+		return google.CredentialsFromJSON(context.Background(), jsonKey, scopes...)
+	}
+}
+
+func mockTokenResponse(t *testing.T) []byte {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+
+	cs := &jws.ClaimSet{}
+	header := &jws.Header{}
+
+	idToken, err := jws.Encode(header, cs, privateKey)
+	if err != nil {
+		t.Fatalf("jws.Encode: %v", err)
+	}
+
+	retVal := struct {
+		IDToken string `json:"id_token"`
+	}{
+		IDToken: idToken,
+	}
+
+	resp, err := json.Marshal(retVal)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	return resp
+}
+
+func assertAuthorizationRequest(t *testing.T, r *http.Request, expectedClientID string) {
+	t.Helper()
+
+	if r.Body == nil {
+		t.Fatal("r.Body is nil")
+	}
+
+	defer r.Body.Close()
+
+	r.ParseForm()
+
+	assertion := r.Form.Get("assertion")
+	if assertion == "" {
+		t.Fatal("empty assertion")
+	}
+
+	assertJWS(t, assertion)
+
+	grantType := r.Form.Get("grant_type")
+	expectedGrantType := "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	if grantType != expectedGrantType {
+		t.Fatalf("grant_type = %s, want %s", grantType, expectedGrantType)
+	}
+}
+
+func assertJWS(t *testing.T, payload string) {
+	s := strings.Split(payload, ".")
+	if len(s) < 2 {
+		t.Fatal("jws: invalid token received")
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(s[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var data map[string]interface{}
+	err = json.NewDecoder(bytes.NewBuffer(decoded)).Decode(&data)
+	if err != nil {
+		t.Fatal("json.Decode:", err)
+	}
+
+	targetAudience := data["target_audience"]
+	if targetAudience != "ABCD" {
+		t.Fatalf("target_audience = %v, want %s", targetAudience, "ABCD")
+	}
+}
+
+func assertAuthorizationHeader(t *testing.T, header string) {
+	t.Helper()
+
+	if header == "" {
+		t.Fatal("empty Authorization header, want Bearer token")
+	}
+
+	if !strings.HasPrefix(header, "Bearer ") {
+		t.Fatalf("header = %s, want Bearer token", header)
+	}
+
+	if len(header) <= len("Bearer ") {
+		t.Fatal("empty Bearer token, want some")
+	}
+}
+
+func brokenCredentialsFn(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+	return nil, fmt.Errorf("brokenCredentialsFn")
 }


### PR DESCRIPTION
This pull request provides a basic IAP authentication functionality.

We don't have any public APIs yet, except the `Transport` struct and its `RoundTrip` function.