### PR TITLE
Export NewTransport function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,36 @@
 iapgo is a Go library to help authenticating access to endpoints behind Google [Cloud Identity-Aware Proxy](https://cloud.google.com/iap/).
 
 This library is heavily using [`golang.org/x/oauth2/google`](https://godoc.org/golang.org/x/oauth2/google) to handle credentials parsing and [authentication](https://cloud.google.com/iap/docs/authentication-howto).
+
+## Usage
+
+```go
+import (
+    "log"
+    "net/http"
+
+    "github.com/saifulwebid/iapgo"
+)
+
+func main() {
+    // Initialize Transport to be used. Define iapClientID with the OAuth Client
+    // ID of the IAP that protects the endpoint.
+    iapClientID := "12345678901-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com"
+
+    // Upon Transport creation, the service account key will be searched using
+    // Application Default Credentials (ADC) strategy described in
+    // https://cloud.google.com/docs/authentication/production.
+    transport, err := iapgo.NewTransport(iapClientID)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Pair Transport with an http.Client.
+    client := &http.Client{
+        Transport: transport,
+    }
+
+    // Access endpoints behind IAP.
+    client.Get("...")
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,30 @@
+package iapgo_test
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/saifulwebid/iapgo"
+)
+
+func Example() {
+	// Initialize Transport to be used. Define iapClientID with the OAuth Client
+	// ID of the IAP that protects the endpoint.
+	iapClientID := "12345678901-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com"
+
+	// Upon Transport creation, the service account key will be searched using
+	// Application Default Credentials (ADC) strategy described in
+	// https://cloud.google.com/docs/authentication/production.
+	transport, err := iapgo.NewTransport(iapClientID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Pair Transport with an http.Client.
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	// Access endpoints behind IAP.
+	client.Get("...")
+}

--- a/iap.go
+++ b/iap.go
@@ -22,7 +22,11 @@ type Transport struct {
 	oauthTransport *oauth2.Transport
 }
 
-func newTransport(clientID string) (*Transport, error) {
+// NewTransport returns an initialized Transport.  It requires OAuth Client ID
+// of the IAP resource target of the Transport.  It finds the service account
+// key using Application Default Credentials (ADC) strategy described in
+// https://cloud.google.com/docs/authentication/production.
+func NewTransport(iapClientID string) (*Transport, error) {
 	transport := &Transport{}
 
 	creds, err := credentialsFinder(context.Background())
@@ -36,7 +40,7 @@ func newTransport(clientID string) (*Transport, error) {
 	}
 
 	conf.PrivateClaims = map[string]interface{}{
-		"target_audience": clientID,
+		"target_audience": iapClientID,
 	}
 
 	conf.UseIDToken = true

--- a/iap_test.go
+++ b/iap_test.go
@@ -29,7 +29,7 @@ func TestNewTransport(t *testing.T) {
 		credentialsFinder = origCredentialsFinder
 	}()
 
-	transport, err := newTransport("ABCD")
+	transport, err := NewTransport("ABCD")
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -46,7 +46,7 @@ func TestNewTransport_CredentialsError(t *testing.T) {
 		credentialsFinder = origCredentialsFinder
 	}()
 
-	transport, err := newTransport("ABCD")
+	transport, err := NewTransport("ABCD")
 	if err == nil {
 		t.Fatal("no error returned")
 	}
@@ -63,7 +63,7 @@ func TestNewTransport_JWTError(t *testing.T) {
 		credentialsFinder = origCredentialsFinder
 	}()
 
-	transport, err := newTransport("ABCD")
+	transport, err := NewTransport("ABCD")
 	if err == nil {
 		t.Fatal("no error returned")
 	}
@@ -95,7 +95,7 @@ func TestTransport_RoundTrip(t *testing.T) {
 		assertAuthorizationHeader(t, r.Header.Get("Authorization"))
 	}))
 
-	transport, err := newTransport(clientID)
+	transport, err := NewTransport(clientID)
 	if err != nil {
 		t.Fatal("newTransport returns error:", err)
 	}


### PR DESCRIPTION
Export `NewTransport` function as the first public API besides `RoundTrip` function.